### PR TITLE
[DEVOPS-2284] bump actions-core to v1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "publish": false
   },
   "dependencies": {
-    "@actions/core": "^1.3.0"
+    "@actions/core": "^1.10.0"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.20.5",


### PR DESCRIPTION
GitHub Actions: Deprecating save-state and set-output commands
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/