### PR TITLE
Feat: Add option to remove octal escape sequences

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Trims output'
     required: false
     default: false
+  containsOctalEscapes:
+    description: 'Removes octal escape sequences'
+    required: false
+    default: false
 outputs:
   content:
     description: 'File content'

--- a/index.js
+++ b/index.js
@@ -6,9 +6,14 @@ const { promises: fs } = require('fs')
 const main = async () => {
   const path = core.getInput('path')
   const trim = core.getBooleanInput('trim')
+  const containsOctalEscapes = core.getBooleanInput('containsOctalEscapes')
   let content = await fs.readFile(path, 'utf8')
   if (trim) {
     content = content.trim()
+  }
+  if (containsOctalEscapes) {
+    const regex = /\\[0-7]{1,3}/gm;
+    content = content.replace(regex, 'OCTAL_ESCAPE')
   }
 
   core.setOutput('content', content)


### PR DESCRIPTION
The output of this step is usually a multi-line string containing single and double quotes, the best way to use it in our workflows is by encapsulating it in a template literal.
Currently we are facing an issue where we might get octal escape sequences in the output, which trigger an error when used inside template literals . More info on this Syntax error here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal

This PR adds an optional input to replace octal escape sequences with a hardcoded string, so that we can use the content of the file inside template strings.